### PR TITLE
Fix linter config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Read .go-version file
         id: goversion
-        run: echo "::set-output name=version::$(cat .go-version)"
+        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: '0'
 
       - name: Read .go-version file
         id: goversion

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Run golangci-lint
         run: >
           go run .github/each-module.go -cmd
-          'golangci-lint run --new-from-rev=HEAD~ --out-format=github-actions --path-prefix=PATH_PREFIX ./...'
+          'golangci-lint run --new-from-rev="HEAD~" --out-format=github-actions --path-prefix=PATH_PREFIX ./...'
 
   go-mod-tidy:
     name: go-mod-tidy

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Read .go-version file
         id: goversion
-        run: echo "::set-output name=version::$(cat .go-version)"
+        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v3
         with:
@@ -30,7 +30,7 @@ jobs:
       - name: Run golangci-lint
         run: >
           go run .github/each-module.go -cmd
-          'golangci-lint run --new-from-rev="HEAD~" --out-format=github-actions --path-prefix=PATH_PREFIX ./...'
+          'golangci-lint run --new-from-rev="HEAD~1" --out-format=github-actions --path-prefix=PATH_PREFIX ./...'
 
   go-mod-tidy:
     name: go-mod-tidy
@@ -40,7 +40,7 @@ jobs:
 
       - name: Read .go-version file
         id: goversion
-        run: echo "::set-output name=version::$(cat .go-version)"
+        run: echo "version=$(cat .go-version)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-go@v3
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,26 +7,23 @@ run:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unused
-    - varcheck
     - depguard
     - errorlint
     - gofumpt
     - goimports
     - godox
-    - ifshort
     - misspell
     - prealloc
     - unconvert
+    - unused
     - revive
   fast: false
 


### PR DESCRIPTION
- Use `--new-from-rev=HEAD~1` as per https://golangci-lint.run/usage/faq/#how-to-integrate-golangci-lint-into-large-project-with-thousands-of-issues.
- Set `fetch-depth: '0'` to get git history.
- Remove deprecated linters.