### PR TITLE
Add parser experiment for logfmt

### DIFF
--- a/logfmt/go.mod
+++ b/logfmt/go.mod
@@ -1,0 +1,5 @@
+module github.com/andrewkroh/go-examples/logfmt
+
+go 1.19
+
+require github.com/alecthomas/participle/v2 v2.0.0-beta.5

--- a/logfmt/go.sum
+++ b/logfmt/go.sum
@@ -1,0 +1,5 @@
+github.com/alecthomas/assert/v2 v2.0.3 h1:WKqJODfOiQG0nEJKFKzDIG3E29CN2/4zR9XGJzKIkbg=
+github.com/alecthomas/participle/v2 v2.0.0-beta.5 h1:y6dsSYVb1G5eK6mgmy+BgI3Mw35a3WghArZ/Hbebrjo=
+github.com/alecthomas/participle/v2 v2.0.0-beta.5/go.mod h1:RC764t6n4L8D8ITAJv0qdokritYSNR3wV5cVwmIEaMM=
+github.com/alecthomas/repr v0.1.0 h1:ENn2e1+J3k09gyj2shc0dHr/yjaWSHRlrJ4DPMevDqE=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=

--- a/logfmt/logfmt.go
+++ b/logfmt/logfmt.go
@@ -1,0 +1,58 @@
+// Package logfmt is a toy parser for log messages encoded in "logfmt". An
+// example message is:
+//
+//	at=info method=GET path=/ host=mutelight.org fwd="124.133.52.161"
+//	dyno=web.2 connect=4ms service=8ms status=200 bytes=1653
+//
+// This is a toy because it's slow, and it can panic for some inputs. This
+// was a learning experiment with github.com/alecthomas/participle/v2.
+//
+// References:
+//
+//	https://www.brandur.org/logfmt
+//	https://github.com/sirupsen/logrus/blob/f8bf7650dccb756cea26edaf9217aab85500fe07/text_formatter.go
+//
+//nolint:govet,revive // Struct-tags use shorthand participle format for readability.
+package logfmt
+
+import (
+	"github.com/alecthomas/participle/v2"
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+var (
+	statefulLexer = lexer.MustStateful(lexer.Rules{
+		"Root": {
+			{"Ident", `[^ =]+`, lexer.Push("Punct")},
+			{"whitespace", `[ \t]+`, nil},
+		},
+		"String": {
+			{"Quoted", `"(\\"|[^"])*"`, lexer.Pop()},
+			{"Unquoted", `[^" ]+`, lexer.Pop()},
+			lexer.Return(),
+		},
+		"Punct": {
+			{`Separator`, `=`, lexer.Push("String")},
+			lexer.Return(),
+		},
+	})
+
+	parser = participle.MustBuild[Message](
+		participle.Lexer(statefulLexer),
+		participle.Unquote("Quoted"),
+	)
+)
+
+type Message struct {
+	KeyValuePairs []Pair `@@*`
+}
+
+type Pair struct {
+	Key   string `@Ident`
+	Value string `( "=" @(Quoted | Unquoted)? )?`
+}
+
+// Parse parses a log message encoded in "logfmt".
+func Parse(message string) (*Message, error) {
+	return parser.ParseString("", message)
+}

--- a/logfmt/logfmt_test.go
+++ b/logfmt/logfmt_test.go
@@ -1,0 +1,141 @@
+package logfmt
+
+import (
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/alecthomas/participle/v2/lexer"
+)
+
+type MessageTest struct {
+	Msg      string
+	Expected []string
+	Error    string
+}
+
+var messageTestCases = []MessageTest{
+	//{Msg: `key=""`, Expected: []string{"key", ""}}, // TODO: Investigate panic.
+	{Msg: `key="value"`, Expected: []string{"key", "value"}},
+	{Msg: "key=value", Expected: []string{"key", "value"}},
+	{Msg: "key= ", Expected: []string{"key", ""}},
+	{Msg: `key="\""`, Expected: []string{"key", `"`}},
+	{Msg: "key= key2=value", Expected: []string{"key", "", "key2", "value"}},
+	{Msg: "key=/foobar", Expected: []string{"key", "/foobar"}},
+	{Msg: "key=foo_bar", Expected: []string{"key", "foo_bar"}},
+	{Msg: "key=foo@bar.com", Expected: []string{"key", "foo@bar.com"}},
+	{Msg: "key=foobar^", Expected: []string{"key", "foobar^"}},
+	{Msg: "key=+/-_^@f.oobar", Expected: []string{"key", "+/-_^@f.oobar"}},
+	{Msg: `key="foo\n\rbar"`, Expected: []string{"key", "foo\n\rbar"}},
+	{Msg: `key="foobar$"`, Expected: []string{"key", "foobar$"}},
+	{Msg: `key="&foobar"`, Expected: []string{"key", "&foobar"}},
+	{Msg: `key="x y"`, Expected: []string{"key", "x y"}},
+	{Msg: `key="x,y"`, Expected: []string{"key", "x,y"}},
+	{Msg: `key="value" key2="value2"`, Expected: []string{"key", "value", "key2", "value2"}},
+	{Msg: "my_key= ", Expected: []string{"my_key", ""}},
+	{Msg: "my.key= ", Expected: []string{"my.key", ""}},
+	{Msg: "my%key= ", Expected: []string{"my%key", ""}},
+	// From: https://www.brandur.org/logfmt
+	{Msg: `key="undefined method ` + "`" + `serialize' for nil:NilClass"`, Expected: []string{"key", "undefined method `serialize' for nil:NilClass"}},
+	// From: https://github.com/kr/logfmt/blob/19f9bcb100e6bcb308b5db29c682de01e9b3f2e6/decode.go#L5
+	{
+		Msg: `foo=bar a=14 baz="hello kitty" cool%story=bro f %^asdf`,
+		Expected: []string{
+			"foo", "bar",
+			"a", "14",
+			"baz", "hello kitty",
+			"cool%story", "bro",
+			"f", "",
+			"%^asdf", "",
+		},
+		Error: "",
+	},
+}
+
+func TestLogfmt(t *testing.T) {
+	for i, tc := range messageTestCases {
+		tc := tc
+		t.Run(tc.Msg, func(t *testing.T) {
+			exr, err := parser.ParseString("test_case_"+strconv.Itoa(i), tc.Msg)
+			if err != nil {
+				t.Error("ParseString failed with:", err)
+				debugLexer(t, statefulLexer, tc.Msg)
+				return
+			}
+
+			observed := make([]string, 0, len(exr.KeyValuePairs)*2)
+			for _, p := range exr.KeyValuePairs {
+				observed = append(observed, p.Key, p.Value)
+			}
+
+			if !reflect.DeepEqual(tc.Expected, observed) {
+				t.Errorf("Error parsing=%v\nwant=[%v]\ngot=[%v]",
+					tc.Msg,
+					strings.Join(tc.Expected, ", "),
+					strings.Join(observed, ", "))
+			}
+		})
+	}
+}
+
+func FuzzReverse(f *testing.F) {
+	for _, tc := range messageTestCases {
+		f.Add(tc.Msg) // Use f.Add to provide a seed corpus
+	}
+
+	f.Fuzz(func(t *testing.T, orig string) {
+		parser.ParseString("", orig) //nolint:errcheck // This is only checking for panics.
+	})
+}
+
+func BenchmarkParse(b *testing.B) {
+	// BenchmarkParse-10          62527             17879 ns/op           17237 B/op        314 allocs/op
+
+	const msg = `level=info msg="Stopping all fetchers" tag=stopping_fetchers id=ConsumerFetcherManager-1382721708341 module=kafka.consumer.ConsumerFetcherManager`
+
+	for i := 0; i < b.N; i++ {
+		_, err := parser.ParseString("", msg)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func debugLexer(t *testing.T, lxDef lexer.Definition, text string) {
+	lx, err := lxDef.Lex("", strings.NewReader(text))
+	if err != nil {
+		t.Fatal("Lex() failed with:", err)
+	}
+
+	consumeTokens(t, lxDef, lx)
+}
+
+func consumeTokens(t *testing.T, lexDef lexer.Definition, lx lexer.Lexer) {
+	tokens := make([]lexer.Token, 0, 1024)
+	for {
+		token, err := lx.Next()
+		if err != nil {
+			t.Error(err)
+			break
+		}
+		tokens = append(tokens, token)
+		if token.Type == lexer.EOF {
+			break
+		}
+	}
+
+	logTokens(t, lexDef, tokens)
+}
+
+func logTokens(t *testing.T, lexDef lexer.Definition, tokens []lexer.Token) {
+	symbols := lexDef.Symbols()
+	tokenToName := make(map[lexer.TokenType]string, len(symbols))
+	for name, id := range symbols {
+		tokenToName[id] = name
+	}
+
+	for _, tok := range tokens {
+		t.Log(tokenToName[tok.Type], ":", tok.Value)
+	}
+}


### PR DESCRIPTION
logfmt is a toy parser for log messages encoded in "logfmt". An example message is:

	at=info method=GET path=/ host=mutelight.org fwd="124.133.52.161"
	dyno=web.2 connect=4ms service=8ms status=200 bytes=1653

This is a toy because it's slow, and it can panic for some inputs. This was a learning experiment with github.com/alecthomas/participle/v2.

It would be interesting to compare this implementation to a Ragel one.

References:

	https://www.brandur.org/logfmt
	https://github.com/sirupsen/logrus/blob/f8bf7650dccb756cea26edaf9217aab85500fe07/text_formatter.go