### PR TITLE
ecs-update - use find/replace to set ecs.version in pipeline

### DIFF
--- a/ecs-update/go.mod
+++ b/ecs-update/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/goccy/go-yaml v1.11.2
 	github.com/mitchellh/go-wordwrap v1.0.1
 	github.com/otiai10/copy v1.11.0
+	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.8.3
 	golang.org/x/exp v0.0.0-20230905200255-921286631fa9
 )
@@ -20,7 +21,6 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/mattn/go-runewidth v0.0.4 // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect


### PR DESCRIPTION
This is a workaround or optimization to avoid unnecessary YAML changes (like loss of white-space). If we only need to change the ECS version, then we will use a find/replace instead of marshaling the modified pipeline data as YAML.