### PR TITLE
fydler - add useecs analyzer

### DIFF
--- a/fydler/internal/analysis/useecs/testdata/fields.yml
+++ b/fydler/internal/analysis/useecs/testdata/fields.yml
@@ -1,0 +1,4 @@
+---
+- name: event.dataset
+  type: constant_keyword
+  value: my_package.logs

--- a/fydler/internal/analysis/useecs/useecs.go
+++ b/fydler/internal/analysis/useecs/useecs.go
@@ -1,0 +1,56 @@
+package useecs
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/andrewkroh/go-ecs"
+
+	"github.com/andrewkroh/go-examples/fydler/internal/analysis"
+)
+
+var Analyzer = &analysis.Analyzer{
+	Name:        "useecs",
+	Description: "Detect fields that exist in the latest version of ECS, but are not using 'external: ecs'.",
+	Run:         run,
+}
+
+var ignoreConstantKeyword bool
+
+func init() {
+	Analyzer.Flags.BoolVar(&ignoreConstantKeyword, "ignore-constant-keyword", false, "Ignore field definitions where ECS declares the type as 'keyword', but the definition uses the more optimized 'constant_keyword' type.")
+}
+
+func run(pass *analysis.Pass) (interface{}, error) {
+	for _, f := range pass.Flat {
+		if f.External != "" {
+			continue
+		}
+
+		ecsField, err := ecs.Lookup(f.Name, "")
+		if err != nil {
+			if errors.Is(err, ecs.ErrFieldNotFound) {
+				continue
+			}
+			// Should never happen.
+			return nil, err
+		}
+
+		if ignoreConstantKeyword && ecsField.DataType == "keyword" && f.Type == "constant_keyword" {
+			continue
+		}
+
+		message := fmt.Sprintf("%s exists in ECS, but the definition is not using 'external: ecs'.", f.Name)
+		if f.Type != "" && ecsField.DataType != f.Type {
+			message += fmt.Sprintf(" The ECS type is %s, but this uses %s.", ecsField.DataType, f.Type)
+		}
+
+		pass.Report(analysis.Diagnostic{
+			Pos:      analysis.NewPos(f.FileMetadata),
+			Category: pass.Analyzer.Name,
+			Message:  message,
+		})
+	}
+
+	return nil, nil
+}

--- a/fydler/internal/analysis/useecs/useecs_test.go
+++ b/fydler/internal/analysis/useecs/useecs_test.go
@@ -1,0 +1,49 @@
+package useecs
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/andrewkroh/go-examples/fydler/internal/analysis"
+	"github.com/andrewkroh/go-examples/fydler/internal/fydler"
+)
+
+func Test(t *testing.T) {
+	testCases := []struct {
+		Path                  string
+		Diags                 []analysis.Diagnostic
+		IgnoreConstantKeyword bool
+	}{
+		{
+			Path: "testdata/fields.yml",
+			Diags: []analysis.Diagnostic{
+				{
+					Pos:      analysis.Pos{File: "testdata/fields.yml", Line: 2, Col: 3},
+					Category: "useecs",
+					Message:  "event.dataset exists in ECS, but the definition is not using 'external: ecs'. The ECS type is keyword, but this uses constant_keyword.",
+				},
+			},
+		},
+		{
+			Path:                  "testdata/fields.yml",
+			IgnoreConstantKeyword: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+
+		t.Run(filepath.Base(tc.Path), func(t *testing.T) {
+			ignoreConstantKeyword = tc.IgnoreConstantKeyword
+
+			_, diags, err := fydler.Run([]*analysis.Analyzer{Analyzer}, tc.Path)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			assert.Equal(t, tc.Diags, diags)
+		})
+	}
+}

--- a/fydler/main.go
+++ b/fydler/main.go
@@ -6,15 +6,17 @@ import (
 	"github.com/andrewkroh/go-examples/fydler/internal/analysis/missingtype"
 	"github.com/andrewkroh/go-examples/fydler/internal/analysis/nesting"
 	"github.com/andrewkroh/go-examples/fydler/internal/analysis/unknownattribute"
+	"github.com/andrewkroh/go-examples/fydler/internal/analysis/useecs"
 	"github.com/andrewkroh/go-examples/fydler/internal/fydler"
 )
 
 func main() {
 	fydler.Main(
+		conflict.Analyzer,
 		duplicate.Analyzer,
 		missingtype.Analyzer,
-		unknownattribute.Analyzer,
-		conflict.Analyzer,
 		nesting.Analyzer,
+		unknownattribute.Analyzer,
+		useecs.Analyzer,
 	)
 }


### PR DESCRIPTION
useecs reports fields that should use `external: ecs` in their definition.