### PR TITLE
ecs-update - Update fields.yml with external: ecs

### DIFF
--- a/ecs-update/README.md
+++ b/ecs-update/README.md
@@ -46,7 +46,18 @@ ecs-update \
   -format-version=3.0.0 \
   -fix-dotted-yaml-keys \
   -add-owner-type \
-  -owner elastic/security-external-integrations
+  -owner elastic/security-external-integrations \
+  packages/*
+```
+
+-----
+
+Update fields.yml files to use `external: ecs` where the field exists
+in the latest version of ECS. And remove [invalid](https://github.com/elastic/package-spec/blob/6be417f6528f5fdd53b31e7ccd42d7039740978e/spec/integration/data_stream/fields/fields.spec.yml#L35-L41)
+attributes from fields.yml definitions (like `footnote`).
+
+```sh
+ecs-update -fields-yml-use-ecs -fields-yml-cleanup-attrs packages/1password
 ```
 
 ## Result report

--- a/ecs-update/go.mod
+++ b/ecs-update/go.mod
@@ -3,7 +3,8 @@ module github.com/andrewkroh/go-examples/ecs-update
 go 1.21
 
 require (
-	github.com/andrewkroh/go-fleetpkg v0.0.8
+	github.com/andrewkroh/go-ecs v0.0.0-20230916014552-bb661ed278a6
+	github.com/andrewkroh/go-fleetpkg v0.0.9
 	github.com/cheggaaa/pb v1.0.29
 	github.com/coreos/go-semver v0.3.1
 	github.com/goccy/go-yaml v1.11.2

--- a/ecs-update/go.sum
+++ b/ecs-update/go.sum
@@ -1,5 +1,7 @@
-github.com/andrewkroh/go-fleetpkg v0.0.8 h1:vKmmGcMPeMIQ+/sS1DHU0jTcERZBpznaNmaq1JbkLME=
-github.com/andrewkroh/go-fleetpkg v0.0.8/go.mod h1:FCFWIeEw6pg5dNFtIQ3f7vNA7iqTtLbiKQUyzjh477s=
+github.com/andrewkroh/go-ecs v0.0.0-20230916014552-bb661ed278a6 h1:UXS7ZhcyFa1q3/P9pmIbEFjFLYOyu7UwbrUnZvudLeo=
+github.com/andrewkroh/go-ecs v0.0.0-20230916014552-bb661ed278a6/go.mod h1:mDhN1WOZsbKaV+wECV+ioF0Lgg4KxMTplkPHTqsj2gQ=
+github.com/andrewkroh/go-fleetpkg v0.0.9 h1:e6fkxfwQNEihK0ep/fb+I4SnE9bp1dLNpop/34cG5UE=
+github.com/andrewkroh/go-fleetpkg v0.0.9/go.mod h1:FCFWIeEw6pg5dNFtIQ3f7vNA7iqTtLbiKQUyzjh477s=
 github.com/cheggaaa/pb v1.0.29 h1:FckUN5ngEk2LpvuG0fw1GEFx6LtyY2pWI/Z2QgCnEYo=
 github.com/cheggaaa/pb v1.0.29/go.mod h1:W40334L7FMC5JKWldsTWbdGjLo0RxUKK73K+TuPxX30=
 github.com/coreos/go-semver v0.3.1 h1:yi21YpKnrx1gt5R+la8n5WgS0kCrsPp33dmEyHReZr4=

--- a/ecs-update/testdata/my_package/data_stream/item_usages/fields/base-fields.yml
+++ b/ecs-update/testdata/my_package/data_stream/item_usages/fields/base-fields.yml
@@ -1,6 +1,9 @@
 - name: input.type
   type: keyword
   description: Input type
+  title: Input type.
+  group: 1
+  level: extended
 - name: data_stream.type
   type: constant_keyword
   description: Data stream type.


### PR DESCRIPTION
Add `-fields-yml-use-ecs` to add `external: ecs` to any field that exists in ECS.

Add `-fields-yml-cleanup-attrs` to remove attributes that should not be defined in any fields.yml files.

It's not pretty but it works.