### PR TITLE
keep expected values when present

### DIFF
--- a/ecs-update/ecs-update.go
+++ b/ecs-update/ecs-update.go
@@ -2114,6 +2114,8 @@ func couldBeECS(query fleetpkg.Field, ecs *ecs.Field) bool {
 	return (query.External == "ecs" || query.Type == ecs.DataType) &&
 		// Constant keywords must remain.
 		(query.Type != "constant_keyword" || query.Value == "") &&
+		// Extensions must remain.
+		query.AdditionalAttributes["expected_values"] == nil &&
 		// Attributes for TSDS must remain.
 		query.MetricType == "" &&
 		query.Dimension == nil &&


### PR DESCRIPTION
This is required to make [this](https://github.com/elastic/integrations/pull/10134#issuecomment-2174122541) and [this](https://github.com/elastic/integrations/pull/10134/commits/355092a27da4d514ee6699c4718eb4680a6cfc86) stick.

Please take a look.