### PR TITLE
feat(trace2csv): add JSON array item count for HTTP response bodies

### DIFF
--- a/trace2csv/main.go
+++ b/trace2csv/main.go
@@ -205,6 +205,12 @@ func toMap(t *TraceLog) map[string]string {
 	if t.HTTPResponseBodyBytes != 0 {
 		m["http.response.body.bytes"] = strconv.FormatFloat(t.HTTPResponseBodyBytes, 'f', -1, 64)
 	}
+	if t.HTTPResponseBodyContent != "" {
+		var rawMessages []json.RawMessage
+		if err := json.Unmarshal([]byte(t.HTTPResponseBodyContent), &rawMessages); err == nil {
+			m["http.response.body.array_items"] = strconv.Itoa(len(rawMessages))
+		}
+	}
 	if t.HTTPResponseStatusCode != 0 {
 		m["http.response.status_code"] = strconv.FormatFloat(t.HTTPResponseStatusCode, 'f', -1, 64)
 	}


### PR DESCRIPTION
When HTTPResponseBodyContent can be decoded as a JSON array, add a new field 'http.response.body.array_items' containing the number of items in the array to the CSV output.