### PR TITLE
feat(yaegi-http): add Akamai SIEM profilers and benchmark findings

### DIFF
--- a/yaegi-http/cmd/akamai-direct-prof/main.go
+++ b/yaegi-http/cmd/akamai-direct-prof/main.go
@@ -1,0 +1,801 @@
+// Command akamai-direct-prof runs Akamai SIEM polling natively and records pprof data.
+package main
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"runtime"
+	"runtime/pprof"
+)
+
+const (
+	akamaiAuthType = "EG1-HMAC-SHA256"
+
+	defaultConfigID        = "1"
+	defaultLimit           = 1000
+	defaultPollTimeout     = 8 * time.Second
+	defaultInitialInterval = 1 * time.Hour
+	defaultToLag           = 5 * time.Second
+	defaultOffsetTTL       = 2 * time.Minute
+)
+
+var (
+	programPath        string
+	runDuration        time.Duration
+	cpuProfileDuration time.Duration
+	outDir             string
+
+	errOffsetInvalid = fmt.Errorf("offset is invalid or expired")
+	spaceRE          = regexp.MustCompile(`\s{2,}`)
+	nonceSeq         uint64
+)
+
+type akamaiConfig struct {
+	baseURL      string
+	configID     string
+	clientToken  string
+	clientSecret string
+	accessToken  string
+
+	limit           int
+	pollTimeout     time.Duration
+	pollInterval    time.Duration
+	maxRequests     int
+	offsetTTL       time.Duration
+	initialInterval time.Duration
+	toLag           time.Duration
+
+	initialCursor string
+	initialFrom   int64
+	headersToSign []string
+}
+
+type pollState struct {
+	cursor        string
+	lastRequestAt time.Time
+	lastEventUnix int64
+}
+
+type fetchMode string
+
+const (
+	modeOffset fetchMode = "offset"
+	modeTime   fetchMode = "time"
+)
+
+type offsetContext struct {
+	Offset string
+	Total  int
+	Limit  int
+}
+
+type offsetContextLine struct {
+	Offset string          `json:"offset"`
+	Total  json.RawMessage `json:"total"`
+	Limit  json.RawMessage `json:"limit"`
+}
+
+type eventTimeLine struct {
+	Timestamp      json.RawMessage `json:"timestamp"`
+	Time           json.RawMessage `json:"time"`
+	EventTime      json.RawMessage `json:"eventTime"`
+	EventTimestamp json.RawMessage `json:"event_timestamp"`
+	HTTPMessage    struct {
+		TimeStamp json.RawMessage `json:"timeStamp"`
+		Start     json.RawMessage `json:"start"`
+		End       json.RawMessage `json:"end"`
+	} `json:"httpMessage"`
+}
+
+type fetchResult struct {
+	eventCount    int
+	offsetContext offsetContext
+	lastEventUnix int64
+}
+
+func init() {
+	flag.StringVar(&programPath, "prog", "testdata/programs/akamai.go", "kept for parity; unused by direct runner")
+	flag.DurationVar(&runDuration, "duration", 2*time.Minute, "total run duration")
+	flag.DurationVar(&cpuProfileDuration, "cpu-profile-duration", 30*time.Second, "CPU profile duration")
+	flag.StringVar(&outDir, "out", "profiles-direct", "directory where pprof files are written")
+}
+
+func main() {
+	flag.Parse()
+
+	if runDuration <= 0 {
+		log.Fatal("-duration must be greater than zero")
+	}
+	if cpuProfileDuration <= 0 {
+		log.Fatal("-cpu-profile-duration must be greater than zero")
+	}
+	if runDuration <= cpuProfileDuration {
+		log.Fatal("-duration must be greater than -cpu-profile-duration")
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		log.Fatalf("failed to create output directory %q: %v", outDir, err)
+	}
+
+	env := loadProgramEnv()
+	if _, ok := env["POLL_TIMEOUT"]; !ok {
+		env["POLL_TIMEOUT"] = defaultRunnerPollTimeout(runDuration).String()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runDuration)
+	defer cancel()
+	ctx = context.WithValue(ctx, "env", env)
+
+	start := time.Now()
+	var eventCount int64
+
+	profileDone := make(chan error, 1)
+	go func() {
+		profileDone <- captureProfiles(ctx, runDuration, cpuProfileDuration, outDir)
+	}()
+
+	err := executeAkamai(ctx, http.DefaultClient, func(map[string]any) {
+		atomic.AddInt64(&eventCount, 1)
+	})
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		log.Fatalf("program execution failed: %v", err)
+	}
+
+	if profileErr := <-profileDone; profileErr != nil {
+		log.Fatalf("profiling failed: %v", profileErr)
+	}
+
+	elapsed := time.Since(start)
+	count := atomic.LoadInt64(&eventCount)
+	rate := float64(count) / elapsed.Seconds()
+	log.Printf("done elapsed=%s events=%d eps=%.2f out=%s", elapsed.Round(time.Millisecond), count, rate, outDir)
+}
+
+func executeAkamai(ctx context.Context, c *http.Client, callback func(event map[string]any)) error {
+	cfg, err := readConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	state := pollState{
+		cursor:        cfg.initialCursor,
+		lastEventUnix: cfg.initialFrom,
+	}
+
+	deadline := time.Now().Add(cfg.pollTimeout)
+	var requests, emitted int
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		if cfg.maxRequests > 0 && requests >= cfg.maxRequests {
+			break
+		}
+
+		mode := chooseMode(cfg, state)
+		if mode == modeTime {
+			state.cursor = ""
+		}
+		result, err := fetchOnce(ctx, c, cfg, mode, state, callback)
+		if err != nil {
+			if err == errOffsetInvalid && mode == modeOffset {
+				state.cursor = ""
+				continue
+			}
+			return err
+		}
+
+		requests++
+		state.lastRequestAt = time.Now()
+		if result.offsetContext.Offset != "" {
+			state.cursor = result.offsetContext.Offset
+		}
+		if result.lastEventUnix > state.lastEventUnix {
+			state.lastEventUnix = result.lastEventUnix
+		}
+
+		emitted += result.eventCount
+		if result.eventCount == 0 {
+			break
+		}
+		if result.offsetContext.Offset != "" && result.offsetContext.Total == 0 {
+			break
+		}
+		if cfg.pollInterval > 0 {
+			wait := cfg.pollInterval
+			if remaining := time.Until(deadline); wait > remaining {
+				wait = remaining
+			}
+			t := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return ctx.Err()
+			case <-t.C:
+			}
+		}
+	}
+
+	log.Printf("akamai_siem requests=%d events=%d cursor=%q last_event_unix=%d", requests, emitted, state.cursor, state.lastEventUnix)
+	return nil
+}
+
+func readConfig(ctx context.Context) (akamaiConfig, error) {
+	env, ok := ctx.Value("env").(map[string]string)
+	if !ok {
+		return akamaiConfig{}, fmt.Errorf("failed to get config from context")
+	}
+
+	cfg := akamaiConfig{
+		baseURL:      env["URL"],
+		configID:     withDefault(env["CONFIG_ID"], defaultConfigID),
+		clientToken:  env["CLIENT_TOKEN"],
+		clientSecret: env["CLIENT_SECRET"],
+		accessToken:  env["ACCESS_TOKEN"],
+
+		limit:           parseIntWithDefault(env["LIMIT"], defaultLimit),
+		pollTimeout:     parseDurationWithDefault(env["POLL_TIMEOUT"], defaultPollTimeout),
+		pollInterval:    parseDurationWithDefault(env["POLL_INTERVAL"], 0),
+		maxRequests:     parseIntWithDefault(env["MAX_REQUESTS"], 0),
+		offsetTTL:       parseDurationWithDefault(env["OFFSET_TTL"], defaultOffsetTTL),
+		initialInterval: parseDurationWithDefault(env["INITIAL_INTERVAL"], defaultInitialInterval),
+		toLag:           parseDurationWithDefault(env["TO_LAG"], defaultToLag),
+
+		initialCursor: env["CURSOR"],
+		headersToSign: splitCSV(env["HEADERS_TO_SIGN"]),
+	}
+
+	if cfg.baseURL == "" || cfg.configID == "" || cfg.clientToken == "" || cfg.clientSecret == "" || cfg.accessToken == "" {
+		return akamaiConfig{}, fmt.Errorf("missing required Akamai configuration values")
+	}
+	if cfg.limit <= 0 {
+		return akamaiConfig{}, fmt.Errorf("LIMIT must be greater than zero")
+	}
+	if cfg.pollTimeout <= 0 {
+		return akamaiConfig{}, fmt.Errorf("POLL_TIMEOUT must be greater than zero")
+	}
+	if cfg.initialInterval <= 0 {
+		return akamaiConfig{}, fmt.Errorf("INITIAL_INTERVAL must be greater than zero")
+	}
+	cfg.initialFrom = parseInt64WithDefault(env["FROM"], 0)
+	if cfg.initialFrom == 0 {
+		cfg.initialFrom = time.Now().Add(-cfg.initialInterval).Unix()
+	}
+
+	return cfg, nil
+}
+
+func chooseMode(cfg akamaiConfig, state pollState) fetchMode {
+	if state.cursor == "" {
+		return modeTime
+	}
+	if state.lastRequestAt.IsZero() {
+		return modeOffset
+	}
+	if time.Since(state.lastRequestAt) > cfg.offsetTTL {
+		return modeTime
+	}
+	return modeOffset
+}
+
+func fetchOnce(ctx context.Context, c *http.Client, cfg akamaiConfig, mode fetchMode, state pollState, callback func(map[string]any)) (fetchResult, error) {
+	u, err := buildURL(cfg, mode, state)
+	if err != nil {
+		return fetchResult{}, err
+	}
+
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return fetchResult{}, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+		signRequest(req, cfg)
+
+		resp, err := c.Do(req)
+		if err != nil {
+			return fetchResult{}, fmt.Errorf("request failed: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			resp.Body.Close()
+			if shouldRetryNonceReplay(resp.StatusCode, body) && attempt == 0 {
+				continue
+			}
+			if mode == modeOffset && looksLikeOffsetError(resp.StatusCode, body) {
+				return fetchResult{}, errOffsetInvalid
+			}
+			return fetchResult{}, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		cursor, lastEventUnix, eventCount, err := parseResponse(ctx, resp.Body, callback)
+		resp.Body.Close()
+		if err != nil {
+			return fetchResult{}, err
+		}
+		return fetchResult{
+			eventCount:    eventCount,
+			offsetContext: cursor,
+			lastEventUnix: lastEventUnix,
+		}, nil
+	}
+	return fetchResult{}, fmt.Errorf("request attempts exhausted")
+}
+
+func buildURL(cfg akamaiConfig, mode fetchMode, state pollState) (string, error) {
+	base := strings.TrimSuffix(cfg.baseURL, "/")
+	u, err := url.Parse(base + "/configs/" + url.PathEscape(cfg.configID))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("limit", strconv.Itoa(cfg.limit))
+	switch mode {
+	case modeOffset:
+		q.Set("offset", state.cursor)
+	case modeTime:
+		from := state.lastEventUnix
+		if from == 0 {
+			from = time.Now().Add(-cfg.initialInterval).Unix()
+		}
+		q.Set("from", strconv.FormatInt(from, 10))
+		if cfg.toLag > 0 {
+			to := time.Now().Add(-cfg.toLag).Unix()
+			if to > from {
+				q.Set("to", strconv.FormatInt(to, 10))
+			}
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func parseResponse(ctx context.Context, r io.Reader, callback func(map[string]any)) (offsetContext, int64, int, error) {
+	s := bufio.NewScanner(r)
+	buf := make([]byte, 0, 1024*1024)
+	s.Buffer(buf, 16*1024*1024)
+
+	var (
+		cursor        offsetContext
+		lastEventUnix int64
+		eventCount    int
+	)
+
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+
+		if c, ok, err := decodeOffsetContextLine(line); err != nil {
+			if ctx.Err() != nil && strings.Contains(err.Error(), "unexpected end of JSON input") {
+				break
+			}
+			return offsetContext{}, 0, 0, fmt.Errorf("failed to decode response line as JSON: %w", err)
+		} else if ok {
+			cursor = c
+			continue
+		}
+
+		ts, err := extractEventUnixLine(line)
+		if err != nil {
+			if ctx.Err() != nil && strings.Contains(err.Error(), "unexpected end of JSON input") {
+				break
+			}
+			return offsetContext{}, 0, 0, fmt.Errorf("failed to decode response line as JSON: %w", err)
+		}
+		if ts > lastEventUnix {
+			lastEventUnix = ts
+		}
+		callback(map[string]any{"message": line})
+		eventCount++
+	}
+	if err := s.Err(); err != nil {
+		if ctx.Err() != nil {
+			return cursor, lastEventUnix, eventCount, nil
+		}
+		return offsetContext{}, 0, 0, fmt.Errorf("failed reading response: %w", err)
+	}
+
+	return cursor, lastEventUnix, eventCount, nil
+}
+
+func decodeOffsetContextLine(line string) (offsetContext, bool, error) {
+	if !strings.Contains(line, "\"offset\"") {
+		return offsetContext{}, false, nil
+	}
+
+	var item offsetContextLine
+	if err := json.Unmarshal([]byte(line), &item); err != nil {
+		return offsetContext{}, false, err
+	}
+	if item.Offset == "" {
+		return offsetContext{}, false, nil
+	}
+
+	hasTotal := len(item.Total) > 0
+	hasLimit := len(item.Limit) > 0
+	if !hasTotal && !hasLimit {
+		return offsetContext{}, false, nil
+	}
+
+	total, err := intFromRaw(item.Total)
+	if err != nil {
+		return offsetContext{}, false, err
+	}
+	limit, err := intFromRaw(item.Limit)
+	if err != nil {
+		return offsetContext{}, false, err
+	}
+
+	return offsetContext{
+		Offset: item.Offset,
+		Total:  total,
+		Limit:  limit,
+	}, true, nil
+}
+
+func extractEventUnixLine(line string) (int64, error) {
+	var event eventTimeLine
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return 0, err
+	}
+
+	values := []json.RawMessage{
+		event.Timestamp,
+		event.Time,
+		event.EventTime,
+		event.EventTimestamp,
+		event.HTTPMessage.TimeStamp,
+		event.HTTPMessage.Start,
+		event.HTTPMessage.End,
+	}
+	var latest int64
+	for _, raw := range values {
+		if ts := parseUnixRaw(raw); ts > latest {
+			latest = ts
+		}
+	}
+	return latest, nil
+}
+
+func parseUnixRaw(raw json.RawMessage) int64 {
+	if len(raw) == 0 {
+		return 0
+	}
+	v := strings.TrimSpace(string(raw))
+	if v == "" || v == "null" {
+		return 0
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		s, err := strconv.Unquote(v)
+		if err != nil {
+			return 0
+		}
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+		if ts, err := time.Parse(time.RFC3339, s); err == nil {
+			return ts.Unix()
+		}
+		return 0
+	}
+	if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(v, 64); err == nil {
+		return int64(f)
+	}
+	return 0
+}
+
+func looksLikeOffsetError(statusCode int, body []byte) bool {
+	switch statusCode {
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusGone, http.StatusUnprocessableEntity:
+	default:
+		return false
+	}
+
+	s := strings.ToLower(string(body))
+	return strings.Contains(s, "offset") || strings.Contains(s, "cursor") || strings.Contains(s, "token")
+}
+
+func shouldRetryNonceReplay(statusCode int, body []byte) bool {
+	if statusCode != http.StatusUnauthorized {
+		return false
+	}
+	s := strings.ToLower(string(body))
+	return strings.Contains(s, "nonce") && strings.Contains(s, "already used")
+}
+
+func signRequest(req *http.Request, cfg akamaiConfig) {
+	timestamp := edgegridTimestamp(time.Now())
+	nonce := randomNonce()
+	authPrefix := fmt.Sprintf(
+		"%s client_token=%s;access_token=%s;timestamp=%s;nonce=%s;",
+		akamaiAuthType,
+		cfg.clientToken,
+		cfg.accessToken,
+		timestamp,
+		nonce,
+	)
+
+	msgPath := req.URL.EscapedPath()
+	if req.URL.RawQuery != "" {
+		msgPath = msgPath + "?" + req.URL.RawQuery
+	}
+
+	message := strings.Join([]string{
+		req.Method,
+		req.URL.Scheme,
+		req.URL.Host,
+		msgPath,
+		canonicalizeHeaders(req.Header, cfg.headersToSign),
+		createContentHash(req, 131072),
+		authPrefix,
+	}, "\t")
+
+	signingKey := createSignature(timestamp, cfg.clientSecret)
+	signature := createSignature(message, signingKey)
+	req.Header.Set("Authorization", authPrefix+"signature="+signature)
+}
+
+func edgegridTimestamp(t time.Time) string {
+	return t.UTC().Format("20060102T15:04:05-0700")
+}
+
+func randomNonce() string {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		n := atomic.AddUint64(&nonceSeq, 1)
+		return fmt.Sprintf("%d-%d", time.Now().UnixNano(), n)
+	}
+	n := atomic.AddUint64(&nonceSeq, 1)
+	b[16] = byte(n >> 56)
+	b[17] = byte(n >> 48)
+	b[18] = byte(n >> 40)
+	b[19] = byte(n >> 32)
+	b[20] = byte(n >> 24)
+	b[21] = byte(n >> 16)
+	b[22] = byte(n >> 8)
+	b[23] = byte(n)
+	return hex.EncodeToString(b)
+}
+
+func createSignature(message, secret string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(message))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func canonicalizeHeaders(requestHeaders http.Header, headersToSign []string) string {
+	if len(headersToSign) == 0 {
+		return ""
+	}
+
+	want := make(map[string]struct{}, len(headersToSign))
+	for _, h := range headersToSign {
+		if h == "" {
+			continue
+		}
+		want[strings.ToLower(strings.TrimSpace(h))] = struct{}{}
+	}
+
+	var keys []string
+	for k := range requestHeaders {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var out []string
+	for _, k := range keys {
+		if _, ok := want[strings.ToLower(k)]; !ok {
+			continue
+		}
+		v := strings.TrimSpace(requestHeaders.Get(k))
+		v = strings.ToLower(spaceRE.ReplaceAllString(v, " "))
+		out = append(out, strings.ToLower(k)+":"+v)
+	}
+	return strings.Join(out, "\t")
+}
+
+func createContentHash(req *http.Request, maxBody int) string {
+	if req.Method != http.MethodPost || req.Body == nil {
+		return ""
+	}
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return ""
+	}
+	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	if len(bodyBytes) > maxBody {
+		bodyBytes = bodyBytes[:maxBody]
+	}
+	sum := sha256.Sum256(bodyBytes)
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func intFromRaw(raw json.RawMessage) (int, error) {
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	v := strings.TrimSpace(string(raw))
+	if v == "" || v == "null" {
+		return 0, nil
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		s, err := strconv.Unquote(v)
+		if err != nil {
+			return 0, err
+		}
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, err
+	}
+	return i, nil
+}
+
+func withDefault(v, d string) string {
+	if v == "" {
+		return d
+	}
+	return v
+}
+
+func parseIntWithDefault(v string, d int) int {
+	if v == "" {
+		return d
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return d
+	}
+	return i
+}
+
+func parseInt64WithDefault(v string, d int64) int64 {
+	if v == "" {
+		return d
+	}
+	i, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return d
+	}
+	return i
+}
+
+func parseDurationWithDefault(v string, d time.Duration) time.Duration {
+	if v == "" {
+		return d
+	}
+	dur, err := time.ParseDuration(v)
+	if err != nil {
+		return d
+	}
+	return dur
+}
+
+func loadProgramEnv() map[string]string {
+	env := map[string]string{}
+	for _, kv := range os.Environ() {
+		after, found := strings.CutPrefix(kv, "YAEGI_HTTP_")
+		if !found {
+			continue
+		}
+		parts := strings.SplitN(after, "=", 2)
+		if len(parts) == 2 {
+			env[parts[0]] = parts[1]
+		}
+	}
+	return env
+}
+
+func defaultRunnerPollTimeout(runDuration time.Duration) time.Duration {
+	if runDuration <= 2*time.Second {
+		return runDuration
+	}
+	if runDuration <= 20*time.Second {
+		return runDuration - 1*time.Second
+	}
+	return runDuration - 5*time.Second
+}
+
+func captureProfiles(ctx context.Context, total, cpuDur time.Duration, out string) error {
+	midpoint := total / 2
+	timer := time.NewTimer(midpoint)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return writeHeapProfile(filepath.Join(out, "heap_end.pprof"))
+	case <-timer.C:
+	}
+
+	if err := writeHeapProfile(filepath.Join(out, "heap_mid.pprof")); err != nil {
+		return err
+	}
+	if err := writeCPUProfile(filepath.Join(out, "cpu_mid.pprof"), cpuDur); err != nil {
+		return err
+	}
+	return writeHeapProfile(filepath.Join(out, "heap_end.pprof"))
+}
+
+func writeCPUProfile(path string, d time.Duration) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create CPU profile %q: %w", path, err)
+	}
+	defer f.Close()
+
+	if err := pprof.StartCPUProfile(f); err != nil {
+		return fmt.Errorf("failed to start CPU profile: %w", err)
+	}
+	time.Sleep(d)
+	pprof.StopCPUProfile()
+	return nil
+}
+
+func writeHeapProfile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create heap profile %q: %w", path, err)
+	}
+	defer f.Close()
+
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("failed to write heap profile: %w", err)
+	}
+	return nil
+}

--- a/yaegi-http/cmd/akamai-prof/README.md
+++ b/yaegi-http/cmd/akamai-prof/README.md
@@ -1,0 +1,246 @@
+# akamai-prof
+
+`akamai-prof` runs the interpreted Akamai program and captures pprof data while it runs.
+
+## How To Run
+
+From `yaegi-http`:
+
+```bash
+go run ./cmd/akamai-prof -prog testdata/programs/akamai.go -duration 2m -cpu-profile-duration 30s -out profiles-2m
+```
+
+Flags:
+
+- `-prog` (default `testdata/programs/akamai.go`): interpreted Yaegi program path.
+- `-duration` (default `2m`): total run time.
+- `-cpu-profile-duration` (default `30s`): CPU profile duration (taken at midpoint).
+- `-out` (default `profiles`): output directory for pprof files.
+
+## Environment Variables
+
+This runner forwards all `YAEGI_HTTP_*` variables into the interpreted program config.
+
+Required:
+
+- `YAEGI_HTTP_URL` (for example `https://.../siem/v1`)
+- `YAEGI_HTTP_CLIENT_TOKEN`
+- `YAEGI_HTTP_CLIENT_SECRET`
+- `YAEGI_HTTP_ACCESS_TOKEN`
+
+Common optional variables:
+
+- `YAEGI_HTTP_CONFIG_ID` (default `1`)
+- `YAEGI_HTTP_LIMIT` (default `1000`)
+- `YAEGI_HTTP_INITIAL_INTERVAL` (default `1h`, used to compute initial `from` when `FROM` is unset)
+- `YAEGI_HTTP_FROM` (explicit initial unix timestamp override)
+- `YAEGI_HTTP_POLL_TIMEOUT` (if unset, runner sets it to `-duration`)
+- `YAEGI_HTTP_MAX_REQUESTS`
+- `YAEGI_HTTP_POLL_INTERVAL`
+- `YAEGI_HTTP_OFFSET_TTL`
+- `YAEGI_HTTP_TO_LAG`
+- `YAEGI_HTTP_CURSOR`
+- `YAEGI_HTTP_HEADERS_TO_SIGN`
+
+## Example Command
+
+```bash
+YAEGI_HTTP_URL="https://proteus-akamai-5a50ea16.sit.estc.dev/siem/v1" \
+YAEGI_HTTP_CLIENT_TOKEN="your-client-token" \
+YAEGI_HTTP_CLIENT_SECRET="your-client-secret" \
+YAEGI_HTTP_ACCESS_TOKEN="your-access-token" \
+YAEGI_HTTP_LIMIT=50000 \
+YAEGI_HTTP_INITIAL_INTERVAL=1h \
+go run ./cmd/akamai-prof -duration 2m -cpu-profile-duration 30s -out profiles-2m
+```
+
+## What It Measures
+
+- Total events emitted by the interpreted Akamai program callback.
+- Elapsed runtime and computed throughput (`events/sec`).
+- Heap profile at midpoint.
+- CPU profile for the configured CPU profile window, starting at midpoint.
+- Heap profile at end.
+
+## Console Output
+
+At completion, it prints one summary log line:
+
+```text
+done elapsed=<duration> events=<count> eps=<events_per_second> out=<output_dir>
+```
+
+Example:
+
+```text
+done elapsed=2m0.001s events=373056 eps=3108.77 out=profiles-2m
+```
+
+If execution or profiling fails, it exits non-zero with an error log.
+
+## Profiling Notes (Run: profiles-2m-2)
+
+Run command used (credentials redacted):
+
+```bash
+cd /Users/akroh/code/personal/go-examples/yaegi-http && \
+YAEGI_HTTP_URL="https://proteus-akamai-5a50ea16.sit.estc.dev/siem/v1" \
+YAEGI_HTTP_CLIENT_TOKEN="<redacted>" \
+YAEGI_HTTP_CLIENT_SECRET="<redacted>" \
+YAEGI_HTTP_ACCESS_TOKEN="<redacted>" \
+YAEGI_HTTP_LIMIT="60000" \
+YAEGI_HTTP_INITIAL_INTERVAL="5h" \
+go run ./cmd/akamai-prof -prog testdata/programs/akamai.go -duration 2m -cpu-profile-duration 30s -out profiles-2m-2
+```
+
+Observed run result:
+
+```text
+akamai_siem requests=26 events=1560000 ... last_event_unix=1771340890
+done elapsed=1m55.658s events=1560000 eps=13488.09 out=profiles-2m-2
+```
+
+CPU profile highlights (`cpu_mid.pprof`):
+
+- Dominant cost is I/O + decompression path:
+  - `syscall.syscall` about 40% flat
+  - `compress/flate` / `compress/gzip` read path about 40% cumulative
+- Yaegi interpreter + reflection dispatch is also significant:
+  - `github.com/traefik/yaegi/interp.*` call stack up to about 54% cumulative
+  - `reflect.Value.Call` path about 47% cumulative
+- JSON decode is present but smaller than I/O/interpreter overhead:
+  - `encoding/json.Unmarshal` about 5.7% cumulative
+- GC work is visible in cumulative runtime stacks (`gcDrain`, `scanobject`, mark workers), consistent with high allocation churn.
+
+Heap profile highlights (`heap_mid.pprof`, `heap_end.pprof`):
+
+- Live heap (in-use) remained low:
+  - midpoint: about 8.37 MB
+  - end: about 7.18 MB
+- No sign of monotonic heap growth in these snapshots.
+- Largest in-use contributors are runtime/worker structures and Yaegi interpreter setup state.
+
+Allocation profile highlights (`alloc_space`):
+
+- Total allocated bytes are large despite low live heap:
+  - midpoint cumulative alloc: about 13.31 GB
+  - end cumulative alloc: about 20.16 GB
+- Main alloc sources:
+  - `yaegi/interp.newFrame`
+  - `reflect.New`
+  - `encoding/json.(*decodeState).objectInterface`
+  - scanner string materialization (`bufio.Scanner.Text`) and JSON unquote/string conversion.
+
+Interpretation:
+
+- Throughput near 13.5k eps is currently bounded more by compressed HTTP read + interpreter/reflect overhead and allocation churn than by peak resident memory.
+
+## Yaegi vs Direct Comparison (2-minute runs)
+
+This section compares:
+
+- Interpreted run: `profiles-2m-2` (`akamai-prof` + Yaegi program)
+- Native run: `profiles-direct-2m` (`akamai-direct-prof` with equivalent Akamai logic)
+
+### Throughput
+
+- Yaegi interpreted: `13488.09 eps`
+- Direct native: `13555.26 eps`
+
+The delta is small (~0.5%), so interpreter overhead is not the dominant throughput limiter in this workload.
+
+### CPU profile comparison
+
+Interpreted (`profiles-2m-2/cpu_mid.pprof`):
+
+- Yaegi/reflect dispatch is significant:
+  - `github.com/traefik/yaegi/interp.*` up to ~53.68% cumulative
+  - `reflect.Value.Call` path ~47.35% cumulative
+- I/O + decompression path is also large:
+  - syscall/TLS/http2/gzip stack roughly ~40%
+- JSON decode appears but is secondary:
+  - `encoding/json.Unmarshal` ~5.73% cumulative
+
+Direct (`profiles-direct-2m/cpu_mid.pprof`):
+
+- No Yaegi/reflect-call wall.
+- Dominated by I/O + decompression:
+  - `syscall.syscall` ~59.61% flat
+  - gzip/flate read path ~60% cumulative
+- JSON decode cost is more visible:
+  - `encoding/json.Unmarshal` ~11.03% cumulative
+
+Summary: removing Yaegi shifts CPU from interpreter/reflect overhead to I/O/decompression and JSON decode, but overall eps remains similar because transport/decompression is the main limiter.
+
+### Live heap comparison (`inuse_space`)
+
+- Yaegi midpoint: ~8.37 MB
+- Yaegi end: ~7.18 MB
+- Direct midpoint: ~4.80 MB
+- Direct end: ~4.28 MB
+
+Direct uses less live heap (~40% lower), and both runs appear stable (no sign of monotonic growth in the sampled snapshots).
+
+### Allocation churn (`alloc_space`)
+
+Interpreted cumulative allocations:
+
+- midpoint: ~13.31 GB
+- end: ~20.16 GB
+
+Direct cumulative allocations:
+
+- midpoint: ~5.26 GB
+- end: ~8.00 GB
+
+Direct reduces allocation churn by roughly 2.5x. The interpreted run spends more allocations in Yaegi frame/reflect internals (`yaegi/interp.newFrame`, `reflect.New`) in addition to JSON decode and scanner string materialization.
+
+## Reduced Parsing Experiment (2-minute runs)
+
+Goal: reduce JSON allocation by avoiding full event decoding. Instead of decoding each event into `map[string]any`, forward raw NDJSON as `{"message":"<raw-line>"}` and parse only control fields needed by the client (`offset`, `total`, `limit`, and minimal timestamp fields for fallback state).
+
+Compared profiles:
+
+- Yaegi baseline: `profiles-2m-2`
+- Yaegi reduced-parse: `profiles-yaegi-2m-minparse`
+- Direct baseline: `profiles-direct-2m`
+- Direct reduced-parse: `profiles-direct-2m-minparse`
+
+### Throughput (full 2-minute)
+
+- Yaegi baseline: `13488.09 eps`
+- Yaegi reduced-parse: `13478.38 eps`
+- Direct baseline: `13555.26 eps`
+- Direct reduced-parse: `13465.12 eps`
+
+Result: throughput remained in the same band (~13.4k eps). Reduced parsing did not materially increase eps.
+
+### Allocation churn (`alloc_space`, end snapshot)
+
+- Yaegi baseline: ~20.16 GB
+- Yaegi reduced-parse: ~25.80 GB
+- Direct baseline: ~8.00 GB
+- Direct reduced-parse: ~3.50 GB
+
+Result:
+
+- Direct path improved significantly in allocation churn (~56% reduction).
+- Yaegi path regressed in allocation churn (~28% increase), likely because the reduced-parse path still performs per-line decoding and the interpreted execution path amplifies per-call/per-type overhead.
+
+### Interpretation
+
+- For direct/native execution, reduced parsing is still useful for memory-pressure and GC-effort reduction.
+- For Yaegi execution, reduced parsing as currently implemented does not reduce allocator pressure and should not be considered a performance win yet.
+- In both paths, eps stayed near ~13.5k because transport/decompression and single-stream polling are still the dominant bottlenecks.
+
+## Updated Conclusion
+
+If the target is substantially higher throughput (for example ~30k eps), the most likely path is **parallelism across independent streams**, not just further single-stream micro-optimizations.
+
+Practical direction:
+
+- Run multiple workers in parallel across multiple `configId` values.
+- Maintain cursor/state independently per `configId`.
+- Aggregate outputs downstream (for example to Elasticsearch) while preserving per-stream ordering.
+
+Single-stream optimization still matters for efficiency, but current evidence indicates it is unlikely to double throughput on its own.

--- a/yaegi-http/cmd/akamai-prof/main.go
+++ b/yaegi-http/cmd/akamai-prof/main.go
@@ -1,0 +1,216 @@
+// Command akamai-prof runs an interpreted Yaegi program and records pprof data.
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"log"
+	"net/http"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/traefik/yaegi/interp"
+	"github.com/traefik/yaegi/stdlib"
+	"runtime"
+	"runtime/pprof"
+)
+
+// ExecuteFunc represents the interpreted program entrypoint signature.
+type ExecuteFunc func(ctx context.Context, c *http.Client, callback func(map[string]any)) error
+
+var executeFuncType = reflect.TypeOf((ExecuteFunc)(nil))
+
+var (
+	programPath        string
+	runDuration        time.Duration
+	cpuProfileDuration time.Duration
+	outDir             string
+)
+
+func init() {
+	flag.StringVar(&programPath, "prog", "testdata/programs/akamai.go", "path to interpreted program")
+	flag.DurationVar(&runDuration, "duration", 2*time.Minute, "total run duration")
+	flag.DurationVar(&cpuProfileDuration, "cpu-profile-duration", 30*time.Second, "CPU profile duration")
+	flag.StringVar(&outDir, "out", "profiles", "directory where pprof files are written")
+}
+
+func main() {
+	flag.Parse()
+
+	if runDuration <= 0 {
+		log.Fatal("-duration must be greater than zero")
+	}
+	if cpuProfileDuration <= 0 {
+		log.Fatal("-cpu-profile-duration must be greater than zero")
+	}
+	if runDuration <= cpuProfileDuration {
+		log.Fatal("-duration must be greater than -cpu-profile-duration")
+	}
+
+	progBytes, err := os.ReadFile(programPath)
+	if err != nil {
+		log.Fatalf("failed to read program %q: %v", programPath, err)
+	}
+	prog := string(progBytes)
+
+	execFn, err := loadExecuteFunc(prog)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		log.Fatalf("failed to create output directory %q: %v", outDir, err)
+	}
+
+	env := loadProgramEnv()
+	// Keep interpreter loop bounded and let it stop before context deadline
+	// so active response reads can finish cleanly.
+	if _, ok := env["POLL_TIMEOUT"]; !ok {
+		env["POLL_TIMEOUT"] = defaultPollTimeout(runDuration).String()
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), runDuration)
+	defer cancel()
+	ctx = context.WithValue(ctx, "env", env)
+
+	start := time.Now()
+	var eventCount int64
+
+	profileDone := make(chan error, 1)
+	go func() {
+		profileDone <- captureProfiles(ctx, runDuration, cpuProfileDuration, outDir)
+	}()
+
+	err = execFn(ctx, http.DefaultClient, func(map[string]any) {
+		atomic.AddInt64(&eventCount, 1)
+	})
+	if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+		log.Fatalf("program execution failed: %v", err)
+	}
+
+	if profileErr := <-profileDone; profileErr != nil {
+		log.Fatalf("profiling failed: %v", profileErr)
+	}
+
+	elapsed := time.Since(start)
+	count := atomic.LoadInt64(&eventCount)
+	rate := float64(count) / elapsed.Seconds()
+	log.Printf("done elapsed=%s events=%d eps=%.2f out=%s", elapsed.Round(time.Millisecond), count, rate, outDir)
+}
+
+func loadExecuteFunc(prog string) (ExecuteFunc, error) {
+	i := interp.New(interp.Options{})
+	if err := i.Use(stdlib.Symbols); err != nil {
+		return nil, err
+	}
+
+	if _, err := i.Eval(prog); err != nil {
+		return nil, fmt.Errorf("failed to evaluate program: %w", err)
+	}
+
+	pkgName, err := packageName(prog)
+	if err != nil {
+		return nil, err
+	}
+
+	fn, err := i.Eval(pkgName + ".Execute")
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate %q: %w", pkgName+".Execute", err)
+	}
+
+	if fn.Type().Kind() != reflect.Func || !fn.Type().ConvertibleTo(executeFuncType) {
+		return nil, fmt.Errorf("Execute signature must be %s", executeFuncType)
+	}
+	return fn.Convert(executeFuncType).Interface().(ExecuteFunc), nil
+}
+
+func captureProfiles(ctx context.Context, total, cpuDur time.Duration, out string) error {
+	midpoint := total / 2
+	timer := time.NewTimer(midpoint)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return writeHeapProfile(filepath.Join(out, "heap_end.pprof"))
+	case <-timer.C:
+	}
+
+	if err := writeHeapProfile(filepath.Join(out, "heap_mid.pprof")); err != nil {
+		return err
+	}
+	if err := writeCPUProfile(filepath.Join(out, "cpu_mid.pprof"), cpuDur); err != nil {
+		return err
+	}
+	return writeHeapProfile(filepath.Join(out, "heap_end.pprof"))
+}
+
+func writeCPUProfile(path string, d time.Duration) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create CPU profile %q: %w", path, err)
+	}
+	defer f.Close()
+
+	if err := pprof.StartCPUProfile(f); err != nil {
+		return fmt.Errorf("failed to start CPU profile: %w", err)
+	}
+	time.Sleep(d)
+	pprof.StopCPUProfile()
+	return nil
+}
+
+func writeHeapProfile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("failed to create heap profile %q: %w", path, err)
+	}
+	defer f.Close()
+
+	// Force GC for a deterministic heap snapshot point.
+	runtime.GC()
+	if err := pprof.WriteHeapProfile(f); err != nil {
+		return fmt.Errorf("failed to write heap profile: %w", err)
+	}
+	return nil
+}
+
+func packageName(prog string) (string, error) {
+	f, err := parser.ParseFile(&token.FileSet{}, "", prog, parser.PackageClauseOnly)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse package name: %w", err)
+	}
+	return f.Name.Name, nil
+}
+
+func loadProgramEnv() map[string]string {
+	env := map[string]string{}
+	for _, kv := range os.Environ() {
+		after, found := strings.CutPrefix(kv, "YAEGI_HTTP_")
+		if !found {
+			continue
+		}
+		parts := strings.SplitN(after, "=", 2)
+		if len(parts) == 2 {
+			env[parts[0]] = parts[1]
+		}
+	}
+	return env
+}
+
+func defaultPollTimeout(runDuration time.Duration) time.Duration {
+	if runDuration <= 2*time.Second {
+		return runDuration
+	}
+	if runDuration <= 20*time.Second {
+		return runDuration - 1*time.Second
+	}
+	return runDuration - 5*time.Second
+}

--- a/yaegi-http/testdata/programs/akamai.go
+++ b/yaegi-http/testdata/programs/akamai.go
@@ -1,0 +1,665 @@
+package programs
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/url"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	akamaiAuthType = "EG1-HMAC-SHA256"
+
+	defaultConfigID = "1"
+
+	defaultLimit           = 1000
+	defaultPollTimeout     = 8 * time.Second
+	defaultInitialInterval = 1 * time.Hour
+	defaultToLag           = 5 * time.Second
+	defaultOffsetTTL       = 2 * time.Minute
+)
+
+var (
+	errOffsetInvalid = fmt.Errorf("offset is invalid or expired")
+	spaceRE          = regexp.MustCompile(`\s{2,}`)
+	nonceSeq         uint64
+)
+
+type akamaiConfig struct {
+	baseURL      string
+	configID     string
+	clientToken  string
+	clientSecret string
+	accessToken  string
+
+	limit           int
+	pollTimeout     time.Duration
+	pollInterval    time.Duration
+	maxRequests     int
+	offsetTTL       time.Duration
+	initialInterval time.Duration
+	toLag           time.Duration
+
+	initialCursor string
+	initialFrom   int64
+	headersToSign []string
+}
+
+type pollState struct {
+	cursor        string
+	lastRequestAt time.Time
+	lastEventUnix int64
+}
+
+type fetchMode string
+
+const (
+	modeOffset fetchMode = "offset"
+	modeTime   fetchMode = "time"
+)
+
+type offsetContext struct {
+	Offset string
+	Total  int
+	Limit  int
+}
+
+type offsetContextLine struct {
+	Offset string          `json:"offset"`
+	Total  json.RawMessage `json:"total"`
+	Limit  json.RawMessage `json:"limit"`
+}
+
+type eventTimeLine struct {
+	Timestamp      json.RawMessage `json:"timestamp"`
+	Time           json.RawMessage `json:"time"`
+	EventTime      json.RawMessage `json:"eventTime"`
+	EventTimestamp json.RawMessage `json:"event_timestamp"`
+	HTTPMessage    struct {
+		TimeStamp json.RawMessage `json:"timeStamp"`
+		Start     json.RawMessage `json:"start"`
+		End       json.RawMessage `json:"end"`
+	} `json:"httpMessage"`
+}
+
+type fetchResult struct {
+	eventCount    int
+	offsetContext offsetContext
+	lastEventUnix int64
+}
+
+// Execute fetches Akamai SIEM events and emits each event through callback.
+//
+// It starts with time-based mode (`from`) and then uses cursor-based mode (`offset`)
+// for subsequent requests. If the cursor is stale for more than two minutes, or if
+// the API rejects the cursor, it falls back to time-based mode using the last seen
+// event timestamp.
+func Execute(ctx context.Context, c *http.Client, callback func(event map[string]any)) error {
+	cfg, err := readConfig(ctx)
+	if err != nil {
+		return err
+	}
+
+	state := pollState{
+		cursor:        cfg.initialCursor,
+		lastEventUnix: cfg.initialFrom,
+	}
+
+	deadline := time.Now().Add(cfg.pollTimeout)
+	var requests, emitted int
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		if time.Now().After(deadline) {
+			break
+		}
+		if cfg.maxRequests > 0 && requests >= cfg.maxRequests {
+			break
+		}
+
+		mode := chooseMode(cfg, state)
+		if mode == modeTime {
+			state.cursor = ""
+		}
+		result, err := fetchOnce(ctx, c, cfg, mode, state, callback)
+		if err != nil {
+			// Cursor may be rejected by the API when it is too old.
+			if err == errOffsetInvalid && mode == modeOffset {
+				state.cursor = ""
+				continue
+			}
+			return err
+		}
+
+		requests++
+		state.lastRequestAt = time.Now()
+		if result.offsetContext.Offset != "" {
+			state.cursor = result.offsetContext.Offset
+		}
+		if result.lastEventUnix > state.lastEventUnix {
+			state.lastEventUnix = result.lastEventUnix
+		}
+
+		emitted += result.eventCount
+		if result.eventCount == 0 {
+			break
+		}
+		if result.offsetContext.Offset != "" && result.offsetContext.Total == 0 {
+			break
+		}
+		if cfg.pollInterval > 0 {
+			wait := cfg.pollInterval
+			if remaining := time.Until(deadline); wait > remaining {
+				wait = remaining
+			}
+			t := time.NewTimer(wait)
+			select {
+			case <-ctx.Done():
+				t.Stop()
+				return ctx.Err()
+			case <-t.C:
+			}
+		}
+	}
+
+	log.Printf("akamai_siem requests=%d events=%d cursor=%q last_event_unix=%d", requests, emitted, state.cursor, state.lastEventUnix)
+	return nil
+}
+
+func readConfig(ctx context.Context) (akamaiConfig, error) {
+	env, ok := ctx.Value("env").(map[string]string)
+	if !ok {
+		return akamaiConfig{}, fmt.Errorf("failed to get config from context")
+	}
+
+	cfg := akamaiConfig{
+		baseURL:      env["URL"],
+		configID:     withDefault(env["CONFIG_ID"], defaultConfigID),
+		clientToken:  env["CLIENT_TOKEN"],
+		clientSecret: env["CLIENT_SECRET"],
+		accessToken:  env["ACCESS_TOKEN"],
+
+		limit:           parseIntWithDefault(env["LIMIT"], defaultLimit),
+		pollTimeout:     parseDurationWithDefault(env["POLL_TIMEOUT"], defaultPollTimeout),
+		pollInterval:    parseDurationWithDefault(env["POLL_INTERVAL"], 0),
+		maxRequests:     parseIntWithDefault(env["MAX_REQUESTS"], 0),
+		offsetTTL:       parseDurationWithDefault(env["OFFSET_TTL"], defaultOffsetTTL),
+		initialInterval: parseDurationWithDefault(env["INITIAL_INTERVAL"], defaultInitialInterval),
+		toLag:           parseDurationWithDefault(env["TO_LAG"], defaultToLag),
+
+		initialCursor: env["CURSOR"],
+		headersToSign: splitCSV(env["HEADERS_TO_SIGN"]),
+	}
+
+	if cfg.baseURL == "" || cfg.configID == "" || cfg.clientToken == "" || cfg.clientSecret == "" || cfg.accessToken == "" {
+		return akamaiConfig{}, fmt.Errorf("missing required Akamai configuration values")
+	}
+	if cfg.limit <= 0 {
+		return akamaiConfig{}, fmt.Errorf("LIMIT must be greater than zero")
+	}
+	if cfg.pollTimeout <= 0 {
+		return akamaiConfig{}, fmt.Errorf("POLL_TIMEOUT must be greater than zero")
+	}
+	if cfg.initialInterval <= 0 {
+		return akamaiConfig{}, fmt.Errorf("INITIAL_INTERVAL must be greater than zero")
+	}
+	cfg.initialFrom = parseInt64WithDefault(env["FROM"], 0)
+	if cfg.initialFrom == 0 {
+		cfg.initialFrom = time.Now().Add(-cfg.initialInterval).Unix()
+	}
+
+	return cfg, nil
+}
+
+func chooseMode(cfg akamaiConfig, state pollState) fetchMode {
+	if state.cursor == "" {
+		return modeTime
+	}
+	if state.lastRequestAt.IsZero() {
+		return modeOffset
+	}
+	if time.Since(state.lastRequestAt) > cfg.offsetTTL {
+		return modeTime
+	}
+	return modeOffset
+}
+
+func fetchOnce(ctx context.Context, c *http.Client, cfg akamaiConfig, mode fetchMode, state pollState, callback func(map[string]any)) (fetchResult, error) {
+	u, err := buildURL(cfg, mode, state)
+	if err != nil {
+		return fetchResult{}, err
+	}
+
+	for attempt := 0; attempt < 2; attempt++ {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, u, nil)
+		if err != nil {
+			return fetchResult{}, fmt.Errorf("failed to create request: %w", err)
+		}
+		req.Header.Set("Accept", "application/json")
+		signRequest(req, cfg)
+
+		resp, err := c.Do(req)
+		if err != nil {
+			return fetchResult{}, fmt.Errorf("request failed: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(io.LimitReader(resp.Body, 4096))
+			resp.Body.Close()
+			if shouldRetryNonceReplay(resp.StatusCode, body) && attempt == 0 {
+				continue
+			}
+			if mode == modeOffset && looksLikeOffsetError(resp.StatusCode, body) {
+				return fetchResult{}, errOffsetInvalid
+			}
+			return fetchResult{}, fmt.Errorf("unexpected status code %d: %s", resp.StatusCode, strings.TrimSpace(string(body)))
+		}
+
+		cursor, lastEventUnix, eventCount, err := parseResponse(ctx, resp.Body, callback)
+		resp.Body.Close()
+		if err != nil {
+			return fetchResult{}, err
+		}
+		return fetchResult{
+			eventCount:    eventCount,
+			offsetContext: cursor,
+			lastEventUnix: lastEventUnix,
+		}, nil
+	}
+	return fetchResult{}, fmt.Errorf("request attempts exhausted")
+}
+
+func buildURL(cfg akamaiConfig, mode fetchMode, state pollState) (string, error) {
+	base := strings.TrimSuffix(cfg.baseURL, "/")
+	u, err := url.Parse(base + "/configs/" + url.PathEscape(cfg.configID))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse URL: %w", err)
+	}
+
+	q := u.Query()
+	q.Set("limit", strconv.Itoa(cfg.limit))
+	switch mode {
+	case modeOffset:
+		q.Set("offset", state.cursor)
+	case modeTime:
+		from := state.lastEventUnix
+		if from == 0 {
+			from = time.Now().Add(-cfg.initialInterval).Unix()
+		}
+		q.Set("from", strconv.FormatInt(from, 10))
+		if cfg.toLag > 0 {
+			to := time.Now().Add(-cfg.toLag).Unix()
+			if to > from {
+				q.Set("to", strconv.FormatInt(to, 10))
+			}
+		}
+	}
+	u.RawQuery = q.Encode()
+	return u.String(), nil
+}
+
+func parseResponse(ctx context.Context, r io.Reader, callback func(map[string]any)) (offsetContext, int64, int, error) {
+	s := bufio.NewScanner(r)
+	buf := make([]byte, 0, 1024*1024)
+	s.Buffer(buf, 16*1024*1024)
+
+	var (
+		cursor        offsetContext
+		lastEventUnix int64
+		eventCount    int
+	)
+
+	for s.Scan() {
+		line := strings.TrimSpace(s.Text())
+		if line == "" {
+			continue
+		}
+
+		if c, ok, err := decodeOffsetContextLine(line); err != nil {
+			if ctx.Err() != nil && strings.Contains(err.Error(), "unexpected end of JSON input") {
+				break
+			}
+			return offsetContext{}, 0, 0, fmt.Errorf("failed to decode response line as JSON: %w", err)
+		} else if ok {
+			cursor = c
+			continue
+		}
+
+		ts, err := extractEventUnixLine(line)
+		if err != nil {
+			if ctx.Err() != nil && strings.Contains(err.Error(), "unexpected end of JSON input") {
+				break
+			}
+			return offsetContext{}, 0, 0, fmt.Errorf("failed to decode response line as JSON: %w", err)
+		}
+		if ts > lastEventUnix {
+			lastEventUnix = ts
+		}
+		callback(map[string]any{"message": line})
+		eventCount++
+	}
+	if err := s.Err(); err != nil {
+		if ctx.Err() != nil {
+			return cursor, lastEventUnix, eventCount, nil
+		}
+		return offsetContext{}, 0, 0, fmt.Errorf("failed reading response: %w", err)
+	}
+
+	return cursor, lastEventUnix, eventCount, nil
+}
+
+func decodeOffsetContextLine(line string) (offsetContext, bool, error) {
+	if !strings.Contains(line, "\"offset\"") {
+		return offsetContext{}, false, nil
+	}
+
+	var item offsetContextLine
+	if err := json.Unmarshal([]byte(line), &item); err != nil {
+		return offsetContext{}, false, err
+	}
+	if item.Offset == "" {
+		return offsetContext{}, false, nil
+	}
+
+	hasTotal := len(item.Total) > 0
+	hasLimit := len(item.Limit) > 0
+	if !hasTotal && !hasLimit {
+		return offsetContext{}, false, nil
+	}
+
+	total, err := intFromRaw(item.Total)
+	if err != nil {
+		return offsetContext{}, false, err
+	}
+	limit, err := intFromRaw(item.Limit)
+	if err != nil {
+		return offsetContext{}, false, err
+	}
+
+	return offsetContext{
+		Offset: item.Offset,
+		Total:  total,
+		Limit:  limit,
+	}, true, nil
+}
+
+func extractEventUnixLine(line string) (int64, error) {
+	var event eventTimeLine
+	if err := json.Unmarshal([]byte(line), &event); err != nil {
+		return 0, err
+	}
+
+	values := []json.RawMessage{
+		event.Timestamp,
+		event.Time,
+		event.EventTime,
+		event.EventTimestamp,
+		event.HTTPMessage.TimeStamp,
+		event.HTTPMessage.Start,
+		event.HTTPMessage.End,
+	}
+	var latest int64
+	for _, raw := range values {
+		if ts := parseUnixRaw(raw); ts > latest {
+			latest = ts
+		}
+	}
+	return latest, nil
+}
+
+func parseUnixRaw(raw json.RawMessage) int64 {
+	if len(raw) == 0 {
+		return 0
+	}
+	v := strings.TrimSpace(string(raw))
+	if v == "" || v == "null" {
+		return 0
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		s, err := strconv.Unquote(v)
+		if err != nil {
+			return 0
+		}
+		if i, err := strconv.ParseInt(s, 10, 64); err == nil {
+			return i
+		}
+		if ts, err := time.Parse(time.RFC3339, s); err == nil {
+			return ts.Unix()
+		}
+		return 0
+	}
+	if i, err := strconv.ParseInt(v, 10, 64); err == nil {
+		return i
+	}
+	if f, err := strconv.ParseFloat(v, 64); err == nil {
+		return int64(f)
+	}
+	return 0
+}
+
+func intFromRaw(raw json.RawMessage) (int, error) {
+	if len(raw) == 0 {
+		return 0, nil
+	}
+	v := strings.TrimSpace(string(raw))
+	if v == "" || v == "null" {
+		return 0, nil
+	}
+	if len(v) >= 2 && v[0] == '"' && v[len(v)-1] == '"' {
+		s, err := strconv.Unquote(v)
+		if err != nil {
+			return 0, err
+		}
+		i, err := strconv.Atoi(s)
+		if err != nil {
+			return 0, err
+		}
+		return i, nil
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return 0, err
+	}
+	return i, nil
+}
+
+func looksLikeOffsetError(statusCode int, body []byte) bool {
+	switch statusCode {
+	case http.StatusBadRequest, http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound, http.StatusGone, http.StatusUnprocessableEntity:
+	default:
+		return false
+	}
+
+	s := strings.ToLower(string(body))
+	return strings.Contains(s, "offset") || strings.Contains(s, "cursor") || strings.Contains(s, "token")
+}
+
+func shouldRetryNonceReplay(statusCode int, body []byte) bool {
+	if statusCode != http.StatusUnauthorized {
+		return false
+	}
+	s := strings.ToLower(string(body))
+	return strings.Contains(s, "nonce") && strings.Contains(s, "already used")
+}
+
+func signRequest(req *http.Request, cfg akamaiConfig) {
+	timestamp := edgegridTimestamp(time.Now())
+	nonce := randomNonce()
+	authPrefix := fmt.Sprintf(
+		"%s client_token=%s;access_token=%s;timestamp=%s;nonce=%s;",
+		akamaiAuthType,
+		cfg.clientToken,
+		cfg.accessToken,
+		timestamp,
+		nonce,
+	)
+
+	msgPath := req.URL.EscapedPath()
+	if req.URL.RawQuery != "" {
+		msgPath = msgPath + "?" + req.URL.RawQuery
+	}
+
+	message := strings.Join([]string{
+		req.Method,
+		req.URL.Scheme,
+		req.URL.Host,
+		msgPath,
+		canonicalizeHeaders(req.Header, cfg.headersToSign),
+		createContentHash(req, 131072),
+		authPrefix,
+	}, "\t")
+
+	signingKey := createSignature(timestamp, cfg.clientSecret)
+	signature := createSignature(message, signingKey)
+	req.Header.Set("Authorization", authPrefix+"signature="+signature)
+}
+
+func edgegridTimestamp(t time.Time) string {
+	return t.UTC().Format("20060102T15:04:05-0700")
+}
+
+func randomNonce() string {
+	b := make([]byte, 24)
+	if _, err := rand.Read(b); err != nil {
+		// Fallback still provides monotonic uniqueness.
+		n := atomic.AddUint64(&nonceSeq, 1)
+		return fmt.Sprintf("%d-%d", time.Now().UnixNano(), n)
+	}
+	n := atomic.AddUint64(&nonceSeq, 1)
+	b[16] = byte(n >> 56)
+	b[17] = byte(n >> 48)
+	b[18] = byte(n >> 40)
+	b[19] = byte(n >> 32)
+	b[20] = byte(n >> 24)
+	b[21] = byte(n >> 16)
+	b[22] = byte(n >> 8)
+	b[23] = byte(n)
+	return hex.EncodeToString(b)
+}
+
+func createSignature(message, secret string) string {
+	h := hmac.New(sha256.New, []byte(secret))
+	h.Write([]byte(message))
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+func canonicalizeHeaders(requestHeaders http.Header, headersToSign []string) string {
+	if len(headersToSign) == 0 {
+		return ""
+	}
+
+	want := make(map[string]struct{}, len(headersToSign))
+	for _, h := range headersToSign {
+		if h == "" {
+			continue
+		}
+		want[strings.ToLower(strings.TrimSpace(h))] = struct{}{}
+	}
+
+	var keys []string
+	for k := range requestHeaders {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var out []string
+	for _, k := range keys {
+		if _, ok := want[strings.ToLower(k)]; !ok {
+			continue
+		}
+		v := strings.TrimSpace(requestHeaders.Get(k))
+		v = strings.ToLower(spaceRE.ReplaceAllString(v, " "))
+		out = append(out, strings.ToLower(k)+":"+v)
+	}
+	return strings.Join(out, "\t")
+}
+
+func createContentHash(req *http.Request, maxBody int) string {
+	if req.Method != http.MethodPost || req.Body == nil {
+		return ""
+	}
+	bodyBytes, err := io.ReadAll(req.Body)
+	if err != nil {
+		return ""
+	}
+	req.Body = io.NopCloser(bytes.NewBuffer(bodyBytes))
+
+	if len(bodyBytes) > maxBody {
+		bodyBytes = bodyBytes[:maxBody]
+	}
+	sum := sha256.Sum256(bodyBytes)
+	return base64.StdEncoding.EncodeToString(sum[:])
+}
+
+func splitCSV(s string) []string {
+	if strings.TrimSpace(s) == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func withDefault(v, d string) string {
+	if v == "" {
+		return d
+	}
+	return v
+}
+
+func parseIntWithDefault(v string, d int) int {
+	if v == "" {
+		return d
+	}
+	i, err := strconv.Atoi(v)
+	if err != nil {
+		return d
+	}
+	return i
+}
+
+func parseInt64WithDefault(v string, d int64) int64 {
+	if v == "" {
+		return d
+	}
+	i, err := strconv.ParseInt(v, 10, 64)
+	if err != nil {
+		return d
+	}
+	return i
+}
+
+func parseDurationWithDefault(v string, d time.Duration) time.Duration {
+	if v == "" {
+		return d
+	}
+	dur, err := time.ParseDuration(v)
+	if err != nil {
+		return d
+	}
+	return dur
+}


### PR DESCRIPTION
## Summary
- add a new interpreted Akamai SIEM program with EdgeGrid signing, cursor/time fallback behavior, graceful shutdown handling, and minimal control-field parsing for raw NDJSON passthrough
- add two profiling runners: `cmd/akamai-prof` (Yaegi interpreted) and `cmd/akamai-direct-prof` (native direct) to enable apples-to-apples CPU/heap/throughput comparisons
- document the profiling workflow and full benchmark analysis in `cmd/akamai-prof/README.md`, including baseline vs reduced-parse experiments and scaling conclusions

## Test plan
- [x] `go test .` (from `yaegi-http`)
- [x] `go test ./cmd/akamai-direct-prof`
- [x] run interpreted profiler (`cmd/akamai-prof`) with 40s and 2m scenarios against mock Akamai SIEM service
- [x] run direct profiler (`cmd/akamai-direct-prof`) with 40s and 2m scenarios against mock Akamai SIEM service
- [x] inspect generated profiles using `go tool pprof` for CPU and heap analysis